### PR TITLE
Replace iter functions with their not iter alternatives

### DIFF
--- a/tls-table.py
+++ b/tls-table.py
@@ -156,7 +156,7 @@ def get_hex_values():
                 # e.g., ECDHE_RSA_WITH_AES_128_GCM_SHA256 -> ECDHE-RSA-AES128-GCM-SHA256
                 openssl_txt_values[cipher] = text
 
-        for key in openssl_hex_values.iterkeys():
+        for key in openssl_hex_values.keys():
             if openssl_hex_values[key] in cipher_hex_values:
                 cipher_hex_values[openssl_hex_values[key]]['OpenSSL'] = openssl_txt_values[key]
             else:
@@ -242,7 +242,7 @@ def print_output(cipher_hex_values, output_format):
             del(cipher_hex_values[code_point])
 
         # If they don't have a priority, then go by hex value
-        for code_point, ciphers in cipher_hex_values.iteritems():
+        for code_point, ciphers in cipher_hex_values.items():
             __print_wiki_entry(code_point, ciphers)
 
 


### PR DESCRIPTION
I wasn't able to get the OpenSSL ciphers to parse when using the `json` option. 
```
$ python3 tls-table.py json | head -30
Retrieving IANA cipher List
Retrieving NSS cipher list
  Warning: code point 0x00,0x66 (TLS_DHE_DSS_WITH_RC4_128_SHA) not in IANA registry
  Warning: code point 0x00,0x62 (TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA) not in IANA registry
  Warning: code point 0x00,0x64 (TLS_RSA_EXPORT1024_WITH_RC4_56_SHA) not in IANA registry
  Warning: code point 0x00,0x63 (TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA) not in IANA registry
  Warning: code point 0x00,0x65 (TLS_DHE_DSS_EXPORT1024_WITH_RC4_56_SHA) not in IANA registry
Retrieving OpenSSL cipher list
Unable to retrieve or parse OpenSSL cipher list
Retrieving GnuTLS cipher list
  Warning: code point 0x00,0x66 (TLS_DHE_DSS_ARCFOUR_128_SHA1) not in IANA registry
  Warning: code point 0xc1,0x02 (TLS_GOSTR341112_256_28147_CNT_IMIT) not in IANA registry
  ```

When I looked the traceback I noticed the script was using `iteritems` method which no longer works with my version of python (3.8.10). 
```
Traceback (most recent call last):
  File "tls-table.py", line 257, in <module>
    output = get_hex_values()
  File "tls-table.py", line 159, in get_hex_values
    for key in openssl_hex_values.iterkeys():
AttributeError: 'dict' object has no attribute 'iterkeys
```
I tried to fix the error and i got it working with replacing the `iterkeys()` method with the `keys()` method. After that I searched trough the file to look for other iter-like methods and replaced one more occurrence which was used while exporting to the `mediawiki` format. 

I am not sure which python version is being used on the mozilla wiki page for Cipher suites (https://wiki.mozilla.org/Security/Cipher_Suites) to generate the table so I am not sure if any backwards compatibility is required. That's why I am not sure if this is the correct fix.